### PR TITLE
Add `--save-dev` to install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Install package:
 
 ```sh
 # npm
-npm install unplugin-purge-polyfills
+npm install --save-dev unplugin-purge-polyfills
 ```
 
 ```js


### PR DESCRIPTION
Since this is intended as a plugin to folks bundle/builder it makes sense the the common case would be as a dev dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the installation command for the `unplugin-purge-polyfills` package to recommend using `--save-dev`, clarifying its intended use as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->