### PR TITLE
Allow for empty options to be passed.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const CJS_STATIC_IMPORT_RE = /(?<=\s|^|[;}])(const|var|let)((?<imports>[\p{L}\p{
 
 const VIRTUAL_POLYFILL_PREFIX = 'virtual:purge-polyfills:'
 
-export const purgePolyfills = createUnplugin<PurgePolyfillsOptions>((opts) => {
+export const purgePolyfills = createUnplugin<PurgePolyfillsOptions>((opts = {}) => {
   const _knownMods = defu(opts.replacements, defaultPolyfills)
   // Allow passing `false` to disable a polyfill
   for (const mod in _knownMods) {


### PR DESCRIPTION
Allow for empty options to be passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `purgePolyfills` function to handle cases without input options, improving robustness and usability for end-users.

- **Bug Fixes**
	- Resolved potential errors related to undefined options in the `purgePolyfills` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->