### PR TITLE
use Object.hasOwn for has-own replacement

### DIFF
--- a/src/replacements.ts
+++ b/src/replacements.ts
@@ -146,7 +146,7 @@ export const defaultPolyfills: Record<string, Record<string, string>> = {
     default: '(a, p, i) => a.includes(p, i)',
   },
   'has-own': {
-    default: '(obj, prop) => obj.hasOwnProperty(prop)',
+    default: 'Object.hasOwn',
   },
   'has-proto': {
     default: '() => { const foo = { bar: {} }; return ({ __proto__: foo }).bar === foo.bar && !({ __proto__: null } instanceof Object) }',


### PR DESCRIPTION
`obj.hasOwnProperty` will not work if it does not extend from the object prototype, which the original module covers. use `Object.hasOwn` instead which is intended for this